### PR TITLE
ACE Wardrobe Compat - New Addon

### DIFF
--- a/addons/wardrobe_compat/$PBOPREFIX$
+++ b/addons/wardrobe_compat/$PBOPREFIX$
@@ -1,0 +1,1 @@
+rdn\stkr_rtx\addons\wardrobe_compat

--- a/addons/wardrobe_compat/ACE_wardrobe.hpp
+++ b/addons/wardrobe_compat/ACE_wardrobe.hpp
@@ -1,0 +1,1 @@
+class ace

--- a/addons/wardrobe_compat/ACE_wardrobe.hpp
+++ b/addons/wardrobe_compat/ACE_wardrobe.hpp
@@ -1,1 +1,11 @@
-class ace
+#include "\z\ace\addons\wardrobe\script_macros_wardrobe.hpp"
+
+class ace_wardrobe {
+
+    class ace_wardrobe_base;
+    class ace_wardrobe_base_U_gloves_on;
+    class ace_wardrobe_base_U_gloves_off;
+
+    // tba
+
+};

--- a/addons/wardrobe_compat/config.cpp
+++ b/addons/wardrobe_compat/config.cpp
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+
+        // Meta information for editor
+		name = ADDON_NAME;
+
+        author = "$STR_stalker_retextures_author";
+        authors[] = {"Nomas / Redwan S. [AET]", "OverlordZorn [CVO]"};
+        
+        url = "$STR_stalker_retextures_author_URL";
+
+		VERSION_CONFIG;
+
+        // Addon Specific Information
+        // Minimum compatible version. When the game's version is lower, pop-up warning will appear when launching the game.
+        requiredVersion = 2.02;
+
+        // Required addons, used for setting load order.
+        // When any of the addons is missing, pop-up warning will appear when launching the game.
+        requiredAddons[] = {QPVAR(main),"cba_main", "ace_wardrobe"};
+
+		// Optional. If this is 1, if any of requiredAddons[] entry is missing in your game the entire config will be ignored and return no error (but in rpt) so useful to make a compat Mod (Since Arma 3 2.14)
+		skipWhenMissingDependencies = 1;
+        
+        // List of objects (CfgVehicles classes) contained in the addon. Important also for Zeus content (units and groups)
+        units[] = {};
+
+        // List of weapons (CfgWeapons classes) contained in the addon.
+        weapons[] = {};
+
+	};
+};
+
+#include "ACE_wardrobe.hpp"

--- a/addons/wardrobe_compat/script_component.hpp
+++ b/addons/wardrobe_compat/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT wardrobe_compat
+
+// This is being used for the Addon's Name and can be "My Addon Template Framework"
+#define COMPONENT_BEAUTIFIED Compat Addon for ACE Wardrobe
+
+
+#include "\rdn\stkr_rtx\addons\main\script_mod.hpp"
+#include "\rdn\stkr_rtx\addons\main\script_macros.hpp"


### PR DESCRIPTION
Adds compat for ACE Wardrobe Framework
-  [Documentation](https://github.com/acemod/ACE3/blob/c03e4e4059ff9b979f6848f384523aad34acd5e2/docs/wiki/framework/wardrobe-framework.md)

- requires https://github.com/acemod/ACE3/pull/10606
- Since its only config entries, this compat can be shipped before ACE Wardrobe is released



